### PR TITLE
Gracefully handle input files in different directories

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -1,4 +1,5 @@
 import io
+import os
 import sys
 from epub2txt import epub2txt
 from lxml.etree import XMLSyntaxError
@@ -68,9 +69,9 @@ while not done:
     else:
         done = True
 
-components = filepath.split('.')
-components[-1] = 'txt'
-outfile = './output/' + '.'.join(components)
+filename = os.path.basename(filepath)
+basename, ext = os.path.splitext(filename)
+outfile = os.path.join('output', '%s.txt' % (basename, ))
 
 with io.open(outfile, 'w', encoding='utf8') as f:
     f.write(u'---\n')


### PR DESCRIPTION
This change uses `os.path` to determine the basename of the input ePub file and uses this to generate the destination filename, allowing it to handle files in different directories.