### PR TITLE
fix compatibility with python 3.10+, fix bold formatting

### DIFF
--- a/epub2txt/epub2txt.py
+++ b/epub2txt/epub2txt.py
@@ -21,13 +21,13 @@
 """Convert epub to text."""
 # pylint:
 
+from pathlib import Path
 from typing import Any, Callable, List, Union
 
-from pathlib import Path
-
-# for with_func_attrs
-# from typing import Iterable
-from collections import Iterable  # < py38
+try:
+    from collections.abc import Iterable  # python 3.10+
+except ImportError:
+    from collections import Iterable  # python < 3.10
 
 # the rest
 from itertools import zip_longest
@@ -147,7 +147,7 @@ def epub2txt(
             content_string = content_string.replace(u'</i>', u'___SHIFT_OUT_CHARACTER___')
             content_string = content_string.replace(u'<strong>', u'___SHIFT_IN_CHARACTER______SHIFT_IN_CHARACTER___')
             content_string = content_string.replace(u'</strong>', u'___SHIFT_OUT_CHARACTER______SHIFT_OUT_CHARACTER___')
-            content_string = content_string.replace(u'<b>', u'___SHIFT_OUT_CHARACTER______SHIFT_OUT_CHARACTER___')
+            content_string = content_string.replace(u'<b>', u'___SHIFT_IN_CHARACTER______SHIFT_IN_CHARACTER___')
             content_string = content_string.replace(u'</b>', u'___SHIFT_OUT_CHARACTER______SHIFT_OUT_CHARACTER___')
         content = bytes(content_string, 'utf-8')
         root = etree.XML(content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ httpcore==0.12.3
 httpx==0.16.1
 idna==3.3
 logzero==1.7.0
-lxml==4.9.0
+lxml==5.2.2
 rfc3986==1.5.0
 six==1.16.0
 sniffio==1.2.0


### PR DESCRIPTION
This commit fixes:
- incompatibilities of `lxml` with newer python versions
- `collections` from `Iterable` not being available in python 3.10.0 anymore (broke old epub2txt implementation)
- bold text formatting 
